### PR TITLE
Uses https for dependencies.

### DIFF
--- a/.cpd.yml
+++ b/.cpd.yml
@@ -1,18 +1,7 @@
 languages: typescript
 files:
   - src/**/*
-exclude:
-  - src/*.ts
-  - src/models/*.ts
-  - src/service/index.ts
-  - src/memoryModelsRepo/index.ts
-  - src/mongoModelsRepo/index.ts
-  - src/s3StorageRepo/index.ts
-  - src/localStorageRepo/index.ts
-  - src/serviceFactory/**/*.ts
-  - src/repoFactory/**/*.ts
 min-lines: 7
 min-tokens: 50
 debug: false
 skip-comments: true
-skip-regex: (import [\'\w\*\{ \,\.\/\}]+\;*)|(\} from [\'\w\*\{ \,\.\/\}]+\;*)|( {2}[A-Z\d_]+\,)|(export\sdefault\s\(config:\sConfig\)\s=>\s{)|( +return\sasync\s\(opts:\s\w+\):\sPromise<[^>]+>\s=>\s{)|(it\([\'\"\`][\w\s]+[\'\"\`],\s(async)?\s)

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,16 @@
         "@types/node": "8.0.20"
       }
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -773,9 +783,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.29.0.tgz",
-      "integrity": "sha512-nlG9m0YQ0gFhdEdnKDG+XJRB/bW+K6M9Axs01+LScjVamWtd4dEwgyohf/r4voW1efnGi6U6hHHvDQ9tt9BtoA==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.28.0.tgz",
+      "integrity": "sha512-E/Z6050shti9v9ivl0dUClVRM4xaH204jsJmEpNYC6KDTlQwAz+5DdhLzn0tjaL/Mp1P0J1uhZokcSP2RFSwlA==",
       "dev": true
     },
     "color-convert": {
@@ -1107,8 +1117,8 @@
       "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -2437,9 +2447,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -2506,17 +2516,19 @@
       }
     },
     "jscpd": {
-      "version": "git://github.com/ryansmith94/jscpd.git#6c6d1b23cc05f8cefbfe1de589f0245e41cbc482",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-0.6.15.tgz",
+      "integrity": "sha512-i+ZGa5/mH9VIskmtsEd941WWUvpKYXawFaCvDKNv6bQJNgVMGyrVJ4twBH9eqme4rSBQKiR9TloXI1SUH3/lzQ==",
       "dev": true,
       "requires": {
         "blamer": "0.1.13",
         "bluebird": "3.5.0",
         "cli": "1.0.1",
         "cli-table": "0.3.1",
-        "codemirror": "5.29.0",
+        "codemirror": "5.28.0",
         "colors": "1.1.2",
         "glob": "7.1.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "shelljs": "0.7.8",
         "underscore": "1.8.3",
         "winston": "2.3.1"
@@ -2561,16 +2573,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsonwebtoken": {
       "version": "8.0.1",
@@ -3154,6 +3156,7 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.3.0.tgz",
       "integrity": "sha512-ZJsOWVJ25E2C5Qedf4w9ePIv5hrPCdDIsHhq89tRxSJCqyIfDAMh0KoU9xeTu7yHT9ZrxPF7mopq1TCWxtMfkw==",
       "requires": {
+        "JSONStream": "1.3.1",
         "abbrev": "1.1.0",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -3185,7 +3188,6 @@
         "inherits": "2.0.3",
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
-        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "libnpx": "9.2.0",
         "lockfile": "1.0.3",
@@ -3253,6 +3255,24 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true
@@ -3607,24 +3627,6 @@
               "requires": {
                 "read": "1.0.7"
               }
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
             }
           }
         },
@@ -6727,6 +6729,12 @@
         }
       }
     },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -6735,12 +6743,6 @@
         "resolve-from": "2.0.0",
         "semver": "5.4.1"
       }
-    },
-    "require-relative": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-      "dev": true
     },
     "resolve": {
       "version": "1.4.0",
@@ -6929,14 +6931,14 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.3",
+        "interpret": "1.0.4",
         "rechoir": "0.6.2"
       },
       "dependencies": {
         "interpret": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-          "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+          "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
           "dev": true
         }
       }
@@ -7093,11 +7095,6 @@
         "promise-polyfill": "1.1.6"
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-to-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.0.tgz",
@@ -7141,6 +7138,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/winston": "^2.3.3",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",
-    "jscpd": "git://github.com/ryansmith94/jscpd.git#prepublish",
+    "jscpd": "git+https://github.com/ryansmith94/jscpd.git#prepublish",
     "semantic-release": "^8.0.3",
     "tslint": "^5.5.0",
     "tslint-consistent-codestyle": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/winston": "^2.3.3",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",
-    "jscpd": "git+https://github.com/ryansmith94/jscpd.git#prepublish",
+    "jscpd": "^0.6.15",
     "semantic-release": "^8.0.3",
     "tslint": "^5.5.0",
     "tslint-consistent-codestyle": "^1.6.0",


### PR DESCRIPTION
Issue first reported on Gitter by @tkd4444 because they had outbound SSH disabled.

```
npm ERR! Command failed: git clone --template=/root/.npm/_git-remotes/_templates --mirror git://github.com/ryansmith94/jscpd.git /root/.npm/_git-remotes/git-github-com-ryansmith94-jscpd-git-prepublish-59581c35
npm ERR! Cloning into bare repository '/root/.npm/_git-remotes/git-github-com-ryansmith94-jscpd-git-prepublish-59581c35'...
npm ERR! fatal: unable to connect to github.com
```