### PR TITLE
Update xapi-statements to 1.0.16 to fix multiple GET filters.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4905,9 +4905,9 @@
       }
     },
     "xapi-statements": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/xapi-statements/-/xapi-statements-1.0.15.tgz",
-      "integrity": "sha512-L9SO5aKMNwEz8Z8O3b2xxSgqjmtazmKTW3wJIse2NR5qtEf4f7iI6kV3sTjLiE3EBeAoCXzVRuBudNnA8RKpeg==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/xapi-statements/-/xapi-statements-1.0.16.tgz",
+      "integrity": "sha512-0Tt25EHWXK7GoAUlp2KRzaReIgMzTI+A7ZyHLSDAVYFzp+04XB8ikpe42nBc/yLP60jennnyKww46G5m3hQ4uA==",
       "requires": {
         "accept-language-parser": "1.4.1",
         "atob": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "xapi-activities": "^1.1.3",
     "xapi-agents": "^1.1.4",
     "xapi-state": "^1.1.11",
-    "xapi-statements": "^1.0.7"
+    "xapi-statements": "^1.0.16"
   },
   "devDependencies": {
     "@types/dotenv": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3560,9 +3560,9 @@ xapi-state@^1.1.11:
     uuid "^3.0.1"
     xapi-validation "^2.1.0"
 
-xapi-statements@^1.0.7:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/xapi-statements/-/xapi-statements-1.0.15.tgz#4f437cf5dcd9e2a3df965ce1ffc0a1fc758b3858"
+xapi-statements@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/xapi-statements/-/xapi-statements-1.0.16.tgz#9363655ca0ae3c9e8e0bac06914c81df78051d8a"
   dependencies:
     accept-language-parser "^1.4.1"
     atob "^2.0.3"


### PR DESCRIPTION
Closes LearningLocker/learninglocker#1017