### PR TITLE
fix(deps): Updates xapi-statements to ^5.0.13.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,9 +106,9 @@
       }
     },
     "@learninglocker/xapi-statements": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@learninglocker/xapi-statements/-/xapi-statements-5.0.12.tgz",
-      "integrity": "sha512-gJA1kpt3OZ61usnxOWeb/s/w5h79HuIFV6lfi8YKlYmIZvoqgRTHMtWc7SKvBUcblMOz2CT6R97NlKM/jw9DWA==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@learninglocker/xapi-statements/-/xapi-statements-5.0.13.tgz",
+      "integrity": "sha512-AhW73O416rHf73W7Nv/qW4573f7aw0hhVqrwDDyFcabfqNbfkoQDlex1UVRo7CJBhjsFrghUYW3MlyA6H0ptgg==",
       "requires": {
         "@learninglocker/xapi-validation": "2.1.9",
         "accept-language-parser": "1.4.1",
@@ -1916,7 +1916,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
@@ -2556,7 +2556,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@learninglocker/xapi-activities": "^3.0.11",
     "@learninglocker/xapi-agents": "^3.0.8",
     "@learninglocker/xapi-state": "^3.0.8",
-    "@learninglocker/xapi-statements": "^5.0.12",
+    "@learninglocker/xapi-statements": "^5.0.13",
     "boolean": "^0.1.2",
     "dotenv": "^4.0.0",
     "express": "^4.14.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ const newRelicLicenseKey = getStringOption(process.env.NEW_RELIC_LICENSE_KEY, ''
 export default {
   defaultTimeout: getNumberOption(process.env.DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
   express: {
+    allowUndefinedMethod: getBooleanOption(process.env.EXPRESS_ALLOW_UNDEFINED_METHOD, false),
     bodyParserLimit: getStringOption(process.env.EXPRESS_BODY_PARSER_LIMIT, '5mb'),
     morganDirectory: getStringOption(process.env.EXPRESS_MORGAN_DIRECTORY, accessLogsDir),
     port: expressPort,

--- a/src/routers/statements.ts
+++ b/src/routers/statements.ts
@@ -73,6 +73,7 @@ const service = serviceFacade({
   tracker,
 });
 const presenter = presenterFacade({
+  allowUndefinedMethod: config.express.allowUndefinedMethod,
   bodyParserLimit: config.express.bodyParserLimit,
   customRoute: 'xAPI/statements/status',
   customRouteText: 'ok',

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,9 +94,9 @@
     string-to-stream "^1.1.0"
     uuid "^3.0.1"
 
-"@learninglocker/xapi-statements@^5.0.12":
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@learninglocker/xapi-statements/-/xapi-statements-5.0.12.tgz#9edcdc350c47ec9f4fde75af468a35eb7c3e305a"
+"@learninglocker/xapi-statements@^5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@learninglocker/xapi-statements/-/xapi-statements-5.0.13.tgz#14ae317eada74c143b89043552ef6c0ce11aad56"
   dependencies:
     "@learninglocker/xapi-validation" "^2.1.9"
     accept-language-parser "^1.4.1"


### PR DESCRIPTION
Add `EXPRESS_ALLOW_UNDEFINED_METHOD=true` to the ".env" file to enable this. Defaults alternate requests to POSTs when the method isn't set.