### PR TITLE
Fixed logger warning level

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ expressApp.use(app({
 expressApp.listen(config.express.port, () => {
   const port80 = 80;
   if (config.express.port === port80) {
-    logger.warning('Express port set to 80; this will not work on non-root Node processes');
+    logger.warn('Express port set to 80; this will not work on non-root Node processes');
   }
   logger.info(`Listening on port ${config.express.port}`);
   handleListen(logger);


### PR DESCRIPTION
# Issue
`logger.warning(` gave the error 
> 2020-10-05 20:06:00:029 - error: uncaughtException: logger_1.default.warning is not a function

# Solution
Updated the syntax to `logger.warn(`