### PR TITLE
Align About response with the xAPI specification

### DIFF
--- a/src/apps/statements/expressPresenter/getAbout.ts
+++ b/src/apps/statements/expressPresenter/getAbout.ts
@@ -6,7 +6,7 @@ import catchErrors from './utils/catchErrors';
 export default (config: Config) => {
   return catchErrors(config, async (_req: Request, res: Response): Promise<void> => {
     res.status(200).json({
-      'X-Experience-API-Version': xapiHeaderVersion,
+      extensions: {'X-Experience-API-Version': xapiHeaderVersion},
       version: [xapiHeaderVersion],
     });
   });


### PR DESCRIPTION
The About-response should have a field `extensions`, containing a map with key-value pairs. 

https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#28-about-resource