### PR TITLE
chore(deps): bump redis from 3.1.0 to 3.1.2 (LLC-1202)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7561,9 +7561,9 @@ redis-parser@^3.0.0:
     redis-errors "^1.0.0"
 
 redis@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.0.tgz#39daec130d74b78decca93513c61db0af5d86ce6"
-  integrity sha512-//lAOcEtNIKk2ekZibes5oyWKYUVWMvMB71lyD/hS9KRePNkB7AU3nXGkArX6uDKEb2N23EyJBthAv6pagD0uw==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.1.tgz#a44bee7c072dcf685e139048d6a1a4d3b00f5d01"
+  integrity sha512-QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==
   dependencies:
     denque "^1.5.0"
     redis-commands "^1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7561,9 +7561,9 @@ redis-parser@^3.0.0:
     redis-errors "^1.0.0"
 
 redis@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.1.tgz#a44bee7c072dcf685e139048d6a1a4d3b00f5d01"
-  integrity sha512-QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.2.tgz#766851117e80653d23e0ed536254677ab647638c"
+  integrity sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==
   dependencies:
     denque "^1.5.0"
     redis-commands "^1.7.0"


### PR DESCRIPTION
Closes [LLC-1202](https://learningpool.atlassian.net/browse/LLC-1202).

Bot generated PR updates to 3.1.1 which fails build. Manually updates to 3.1.2.

GHSA-35q2-47q7-3pc3
low severity
Vulnerable versions: >= 2.6.0, < 3.1.1
**Patched version: 3.1.1
Impact
When a client is in monitoring mode, the regex begin used to detected monitor messages could cause exponential backtracking on some strings. This issue could lead to a denial of service.**

Patches
The problem was fixed in commit 2d11b6d and was released in version 3.1.1.

References
#1569 (GHSL-2021-026)