### PR TITLE
fix(GitHub Actions): Add missing build step in release job (LLC-2358)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -277,6 +277,9 @@ jobs:
       - name: Installing Dependencies
         run: yarn install --ignore-engines --frozen-lockfile
 
+      - name: Build Package
+        run: yarn build
+
       - name: Run Semantic Release
         run: npm run semantic-release
         env:


### PR DESCRIPTION
Closes LLC-2358.

Adds the missing `yarn build` step in the release job of the integration workflow.