### PR TITLE
fix(types): Replace NodeJS.WritableStream with Writable from stream to remove mocha types (LLC-2372)

### DIFF
--- a/src/apps/statements/expressPresenter/tests/getParts.test.ts
+++ b/src/apps/statements/expressPresenter/tests/getParts.test.ts
@@ -5,7 +5,6 @@ sourceMapSupport.install();
 import assert from 'assert';
 import { Readable as ReadableStream } from 'stream';
 import { map } from 'lodash';
-import 'mocha'; // eslint-disable-line import/no-unassigned-import
 import streamToString from 'stream-to-string';
 import Part from '../../models/Part';
 import getParts from '../utils/getParts';

--- a/src/apps/statements/expressPresenter/utils/getStatements/streamStatementsWithAttachments.ts
+++ b/src/apps/statements/expressPresenter/utils/getStatements/streamStatementsWithAttachments.ts
@@ -1,13 +1,11 @@
+import { Writable } from 'stream';
 import { reduce } from 'bluebird';
+
 import AttachmentModel from '../../../models/AttachmentModel';
 
 export const boundary = 'zzzlearninglockerzzz';
 
-export default async (
-  jsonResponse: any,
-  attachments: AttachmentModel[],
-  stream: NodeJS.WritableStream,
-) => {
+export default async (jsonResponse: any, attachments: AttachmentModel[], stream: Writable) => {
   const crlf = '\r\n';
   const fullBoundary = `${crlf}--${boundary}${crlf}`;
   const stringResponse = JSON.stringify(jsonResponse);


### PR DESCRIPTION
Closes LLC-2372.

`@types/mocha` extends the global `NodeJS.WritableStream` type meaning that there is a path reference to `mocha` in the build declaration file for `src/apps/statements/expressPresenter/utils/getStatements/streamStatementsWithAttachments.ts`:
```TypeScript
/// <reference path="mocha" />
```

This change replace the `NodeJS.WritableStream` type with `Writable` from `stream` which is a class that implements the `NodeJS.WritableStream` interface. This removes the reference to mocha in the declaration file, allowing LL to build this file without having the mocha types dependency.